### PR TITLE
support require

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -20,6 +20,7 @@ export default function ({types: t}) {
         invariants(config)
 
         const firstArg = traverseExpression(t, args[0])
+        if (!firstArg) { return }
         const importPath = firstArg.value.raw || firstArg.value
         if (isImportPathPrefixed(importPath, config.importPathPrefix)) {
           let newValue = getNewValue(config, sourcePath, importPath)
@@ -80,7 +81,6 @@ function getNewValue (config, sourcePath, importPath) {
   const absoluteImportPath = getAbsoluteImportPath(importPath, config)
   const absoluteSourcePath = getAbsoluteSourcePath(config.projectRoot, sourcePath)
   const relativeImportPath = relative(dirname(absoluteSourcePath), absoluteImportPath)
-  console.log(importPath, absoluteImportPath, absoluteSourcePath, relativeImportPath)
   return './' + slash(relativeImportPath)
 }
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,9 +1,37 @@
 import { dirname, join, relative, isAbsolute } from 'path'
 import slash from 'slash'
 
-export default function () {
+export default function ({types: t}) {
   return {
     visitor: {
+      CallExpression (path, state) {
+        if (path.node.callee.name !== 'require') { return }
+        const args = path.node.arguments
+        if (!args.length) { return }
+
+        const config = extractConfig(state)
+
+        const sourcePath = state.file.opts.filename
+
+        if (sourcePath === 'unknown') {
+          return
+        }
+
+        invariants(config)
+
+        const firstArg = traverseExpression(t, args[0])
+        const importPath = firstArg.value.raw || firstArg.value
+        if (isImportPathPrefixed(importPath, config.importPathPrefix)) {
+          let newValue = getNewValue(config, sourcePath, importPath)
+          newValue += importPath === config.importPathPrefix ? '/' : ''
+          if (typeof firstArg.value === 'object') {
+            firstArg.value.raw = newValue
+            firstArg.value.cooked = newValue
+          } else {
+            firstArg.value = newValue
+          }
+        }
+      },
       ImportDeclaration (path, state) {
         // config: {
         //   projectRoot: babel option sourceRoot or process.cwd as fallback
@@ -25,16 +53,35 @@ export default function () {
         const importPath = path.node.source.value
 
         if (isImportPathPrefixed(importPath, config.importPathPrefix)) {
-          const absoluteImportPath = getAbsoluteImportPath(importPath, config)
-
-          const absoluteSourcePath = getAbsoluteSourcePath(config.projectRoot, sourcePath)
-          const relativeImportPath = relative(dirname(absoluteSourcePath), absoluteImportPath)
-
-          path.node.source.value = './' + slash(relativeImportPath)
+          path.node.source.value = getNewValue(config, sourcePath, importPath)
         }
       }
     }
   }
+}
+
+function traverseExpression (t, arg) {
+  if (t.isStringLiteral(arg)) {
+    return arg
+  }
+  if (t.isBinaryExpression(arg)) {
+    return traverseExpression(t, arg.left)
+  }
+  if (t.isTemplateLiteral(arg)) {
+    return traverseExpression(t, arg.quasis[0])
+  }
+  if (t.isTemplateElement(arg)) {
+    return arg
+  }
+  return null
+}
+
+function getNewValue (config, sourcePath, importPath) {
+  const absoluteImportPath = getAbsoluteImportPath(importPath, config)
+  const absoluteSourcePath = getAbsoluteSourcePath(config.projectRoot, sourcePath)
+  const relativeImportPath = relative(dirname(absoluteSourcePath), absoluteImportPath)
+  console.log(importPath, absoluteImportPath, absoluteSourcePath, relativeImportPath)
+  return './' + slash(relativeImportPath)
 }
 
 function extractConfig (state) {

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -17,6 +17,17 @@ describe('Plugin', () => {
       expect(transformedCode.code).to.contain('\"~/dir/test\"')
     })
 
+    it('without filename set (require)', () => {
+      const transformedCode = transform(
+        'const Test = require("~/dir/test")', {
+          sourceRoot: '/project/root/',
+          plugins: [ rootImportPlugin ]
+        }
+      )
+
+      expect(transformedCode.code).to.contain('\"~/dir/test\"')
+    })
+
     it('when import path is not prefixed', () => {
       const transformedCode = transform(
         'import Test from "~/dir/test"', {

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -28,6 +28,18 @@ describe('Plugin', () => {
 
       expect(transformedCode.code).to.contain('\"~/dir/test\"')
     })
+
+    it('when require path does not start with string/template', () => {
+      const transformedCode = transform(
+        'const Test = require(myVar + "/foo")', {
+          filename: '/project/root/otherdir/test.js',
+          sourceRoot: '/project/root/',
+          plugins: [ rootImportPlugin ]
+        }
+      )
+
+      expect(transformedCode.code).to.contain('myVar + \"/foo\"')
+    })
   })
 
   describe('should transform the project relative path to a file relative path', () => {

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -89,6 +89,54 @@ describe('Plugin', () => {
 
       expect(transformedCode.code).to.contain('\"./../dir/test\"')
     })
+
+    it('for string require', () => {
+      const transformedCode = transform(
+        'const Test = require("~/dir/test")', {
+          filename: '/project/root/otherdir/test.js',
+          sourceRoot: '/project/root/',
+          plugins: [ rootImportPlugin ]
+        }
+      )
+
+      expect(transformedCode.code).to.contain('\"./../dir/test\"')
+    })
+
+    it('for a require with expression starting with prefix', () => {
+      const transformedCode = transform(
+        'const Test = require("~/" + "/test")', {
+          filename: '/project/root/otherdir/test.js',
+          sourceRoot: '/project/root/',
+          plugins: [ rootImportPlugin ]
+        }
+      )
+
+      expect(transformedCode.code).to.contain('\"./../" + "/test\"')
+    })
+
+    it('for require that starts with string and has variable', () => {
+      const transformedCode = transform(
+        'const Test = require("~/foo" + myVar + "/test")', {
+          filename: '/project/root/otherdir/test.js',
+          sourceRoot: '/project/root/',
+          plugins: [ rootImportPlugin ]
+        }
+      )
+
+      expect(transformedCode.code).to.contain('\"./../foo" + myVar + "/test\"')
+    })
+
+    it('for require with template string variable', () => {
+      const transformedCode = transform(
+        'const Test = require(`~/${myVar}`)', {
+          filename: '/project/root/otherdir/test.js',
+          sourceRoot: '/project/root/',
+          plugins: [ rootImportPlugin ]
+        }
+      )
+
+      expect(transformedCode.code).to.contain('`./../${ myVar }`')
+    })
   })
 
   describe('should throw an error', () => {


### PR DESCRIPTION
I added support for `require`. As long as it starts with the importPathPrefix, expressions are supported. Transforming template strings is a little odd - the value is an object like `{raw: '~/', cooked: '~/'}`. I assume that changed them both to the new value is the right thing to do here. The test passed =D
